### PR TITLE
Fix an npm error in the windows command prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "watchify": "^3.1.x"
   },
   "scripts": {
-    "start": "npm i inquirer chalk && node start.js;",
+    "start": "npm i inquirer chalk && node start.js",
     "install": "napa"
   },
   "extensions": {

--- a/start.js
+++ b/start.js
@@ -199,9 +199,9 @@ function updateDependencies(dependencies, devDependencies) {
     command += 'npm install --save' + dependencies.join(' ');
   }
   if (devDependencies.join('') !== '') {
-    command += '; npm install --save-dev ' + devDependencies.join(' ');
+    command += ' && npm install --save-dev ' + devDependencies.join(' ');
   }
-  command += '; npm install';
+  command += ' && npm install';
 
   if (dependencies || devDependencies) {
     console.log(chalk.green('Installing dependencies and adding them to package.json...', dependencies.join(' '), devDependencies.join(' ')));


### PR DESCRIPTION
There is a extra semicolon in the package.json file will lead npm wrong when running 'npm start' in the Windows command prompt.