### PR TITLE
Allow importing SCSS files from node_modules

### DIFF
--- a/boilerplate/tasks/styles.js
+++ b/boilerplate/tasks/styles.js
@@ -76,7 +76,9 @@ function getStylesStream(extension) {
       return gulp.src(`${config.src}/styles/main.scss`)
         .pipe(sassGlob())
         .pipe(sourcemaps.init())
-        .pipe(preprocessor());
+        .pipe(preprocessor({
+            includePaths: './node_modules',
+          }));
 
     case 'less':
       return gulp.src(`${config.src}/styles/main.less`)


### PR DESCRIPTION
Thank you for your fantastic work. This will enable developer to import SCSS files from packages (for example from foundation-sites or bootstrap)